### PR TITLE
Small bugfix for absolute paths

### DIFF
--- a/tasks/file-creator.js
+++ b/tasks/file-creator.js
@@ -67,12 +67,7 @@ module.exports = function(grunt) {
           grunt.verbose.writeflags(options, 'Options');
 
           // create path (if needed)
-          var dir = filepath.split(path.sep);
-          dir.pop();
-          if (filepath.indexOf(path.sep) === 0) {
-            dir.unshift(path.sep);
-          }
-          dir = path.join.apply(undefined, dir);
+          var dir = path.dirname(filepath);
           if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, '0777', true);
           }

--- a/tasks/file-creator.js
+++ b/tasks/file-creator.js
@@ -69,6 +69,9 @@ module.exports = function(grunt) {
           // create path (if needed)
           var dir = filepath.split(path.sep);
           dir.pop();
+          if (filepath.indexOf('/') === 0) {
+            dir.unshift('/');
+          }
           dir = path.join.apply(undefined, dir);
           if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, '0777', true);

--- a/tasks/file-creator.js
+++ b/tasks/file-creator.js
@@ -69,8 +69,8 @@ module.exports = function(grunt) {
           // create path (if needed)
           var dir = filepath.split(path.sep);
           dir.pop();
-          if (filepath.indexOf('/') === 0) {
-            dir.unshift('/');
+          if (filepath.indexOf(path.sep) === 0) {
+            dir.unshift(path.sep);
           }
           dir = path.join.apply(undefined, dir);
           if (!fs.existsSync(dir)) {


### PR DESCRIPTION
This pull request fixes an issue where grunt-file-creator doesn't always work properly with absolute paths.

Before writing the file, file-creator checks to see if the directory exists, and creates it if it doesn't. This is proper behavior, but it doesn't work if the path is an absolute path, because doing `filepath.split('/')` and then using `path.join` to recreate it results in stripping the leading `/`.

simple example (excerpt from tasks/file-creator.js:70-75):

``` javascript
// var filepath = '/path/to/my/file.js';
...
var dir = filepath.split(path.sep);
// at this point, dir = [ '', 'path', 'to', 'my', 'file.js' ]

dir.pop();
// now, dir = [ '', 'path', 'to', 'my' ]

dir = path.join.apply(undefined, dir);
// now, dir = 'path/to/my' (no leading slash)

if (!fs.existsSync(dir)) { // doesn't exist, conditional evaluates to true
  fs.mkdirSync(dir, '0777', true); // <-- this fails because 'path/to' is not a real directory
}
```

using the built-in `path` module's `dirname` function fixes that issue:

``` javascript
// var filepath = '/path/to/my/file.js';
var dir = path.dirname(filepath);
// dir = '/path/to/my'
```

Thanks!
